### PR TITLE
Resolving issue JENKINS-13517 (DisplayName)

### DIFF
--- a/src/main/java/hudson/plugins/copyProjectLink/CopyAction.java
+++ b/src/main/java/hudson/plugins/copyProjectLink/CopyAction.java
@@ -16,7 +16,7 @@ public class CopyAction<T extends AbstractItem> implements Action {
 	}
 
 	public String getCloneName() {
-		return item.getDisplayName() + "-clone";
+		return item.getName() + "-clone";
 	}
 
   public T getItem() {
@@ -24,7 +24,7 @@ public class CopyAction<T extends AbstractItem> implements Action {
   }
 
 	public String getItemName() {
-		return item.getDisplayName();
+		return item.getName();
 	}
 
 	public String getIconFileName() {


### PR DESCRIPTION
This plugin does not work when copying projects that have a Display Name set. This resolves that issue.

The issue is here: https://issues.jenkins-ci.org/browse/JENKINS-13517