### PR TITLE
Icorrect relative URLs when using --prefix and folders

### DIFF
--- a/src/main/resources/hudson/plugins/copyProjectLink/CopyAction/index.jelly
+++ b/src/main/resources/hudson/plugins/copyProjectLink/CopyAction/index.jelly
@@ -30,19 +30,19 @@ THE SOFTWARE.
   <l:layout norefresh="true" permission="${permission}" title="${%new(it.item.pronoun)}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <j:set var="parentUrl" value="${rootURL}${h.getRelativeLinkTo(it.item.parent)}"/>
-      <f:form method="post" action="${parentUrl}/createItem">
-      	<f:block>
-    	<f:entry title="${%Job name}">
-    		<f:textbox id="name" name="name" value="${it.cloneName}" checkUrl="'${parentUrl}/checkJobName?value='+encodeURIComponent(this.value)"/>
-   		</f:entry>
-   		<input type="hidden" name="mode" value="copy" />
-   		<input type="hidden" id="from" name="from" value="${it.itemName}"/>
-   		</f:block>
-      	<f:block>
-      		<f:submit name="Submit" value="OK"/>
-    	</f:block>
+      <j:set var="parentUrl" value="${rootURL}/${it.item.parent.url}"/>
+      <f:form method="post" action="${parentUrl}createItem">
+        <f:block>
+          <f:entry title="${%Job name}">
+            <f:textbox id="name" name="name" value="${it.cloneName}" checkUrl="'${parentUrl}checkJobName?value='+encodeURIComponent(this.value)"/>
+          </f:entry>
+          <input type="hidden" name="mode" value="copy" />
+          <input type="hidden" id="from" name="from" value="${it.itemName}"/>
+        </f:block>
+        <f:block>
+          <f:submit name="Submit" value="OK"/>
+        </f:block>
       </f:form>
-   	</l:main-panel>
+    </l:main-panel>
   </l:layout>
 </j:jelly>


### PR DESCRIPTION
In case Jenkins' --prefix argument is set we get icorrect URLs when trying to do a copy from folders.

For example:
/jenkins../../..//createItem
